### PR TITLE
Refresh server definitions from Consul changes

### DIFF
--- a/api/consul.go
+++ b/api/consul.go
@@ -1,8 +1,9 @@
 package api
 
 import (
-	"fmt"
 	consul "github.com/hashicorp/consul/api"
+	"net"
+	"strconv"
 	"strings"
 )
 
@@ -40,7 +41,7 @@ func ServerDefinitionFromServiceEntry(entry *consul.CatalogService) *ServerDefin
 	}
 
 	srv.URL.Scheme = scheme
-	srv.URL.Host = fmt.Sprintf("%s:%d", address, entry.ServicePort)
+	srv.URL.Host = net.JoinHostPort(address, strconv.Itoa(entry.ServicePort))
 	srv.DefaultServer = false
 
 	// Extract a region-<code> identifier from the tags
@@ -52,7 +53,6 @@ func ServerDefinitionFromServiceEntry(entry *consul.CatalogService) *ServerDefin
 
 		if strings.HasPrefix(tag, "region-") {
 			srv.CountryCode = strings.ToLower(strings.TrimPrefix(tag, "region-"))
-			break
 		}
 	}
 

--- a/api/watch.go
+++ b/api/watch.go
@@ -1,0 +1,1 @@
+package api

--- a/api/watch.go
+++ b/api/watch.go
@@ -1,1 +1,0 @@
-package api

--- a/cmd/go-region-router/main.go
+++ b/cmd/go-region-router/main.go
@@ -6,6 +6,7 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/urfave/cli"
 	"log"
+	"net"
 	"net/http"
 	"os"
 	"os/signal"
@@ -20,8 +21,10 @@ type Router struct {
 	Refresh		chan bool
 }
 
-func (r Router) Start() error {
-	return http.ListenAndServe(":7000", region.CountryCodeHandler(r.Region.RegionHandler()(r.mux)))
+func (r Router) Start(host string, port int) error {
+	addr := net.JoinHostPort(host, strconv.Itoa(port))
+	log.Printf("Listening on %s ...", addr)
+	return http.ListenAndServe(addr, region.CountryCodeHandler(r.Region.RegionHandler()(r.mux)))
 }
 
 func NewRouter(config *api.ConsulConfiguration) *Router {
@@ -95,9 +98,7 @@ func main() {
 	}
 
 	app.Action = func(c *cli.Context) error {
-		addr := host + ":" + strconv.Itoa(port)
-		log.Printf("Listening on %s ...", addr)
-		return r.Start()
+		return r.Start(c.String("host"), c.Int("port"))
 	}
 
 	go func() {

--- a/cmd/go-region-router/main.go
+++ b/cmd/go-region-router/main.go
@@ -106,7 +106,7 @@ func main() {
 		cli.IntFlag{
 			Name:			"port",
 			Usage:			"Port to bind to",
-			Value:			7001,
+			Value:			7000,
 			Destination:	&port,
 		},
 	}

--- a/middleware/regionrouter.go
+++ b/middleware/regionrouter.go
@@ -119,8 +119,6 @@ func (reg RegionRouter) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, unavailableStr, http.StatusServiceUnavailable)
 			return
 		}
-
-		return
 	}
 
 	dest, err := url.Parse(target)

--- a/middleware/regionrouter.go
+++ b/middleware/regionrouter.go
@@ -100,6 +100,12 @@ func (reg *RegionRouter) DeleteRegionServer(countryCode string) {
 	reg.mapLock.Unlock()
 }
 
+func (reg *RegionRouter) ResetRegionServers() {
+	reg.mapLock.Lock()
+	reg.m = make(map[string]string)
+	reg.mapLock.Unlock()
+}
+
 func (reg RegionRouter) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	destRegion := r.Header.Get("X-Country-Code")
 	if destRegion == "" {
@@ -160,12 +166,8 @@ func (reg RegionRouter) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	reg.h.ServeHTTP(w, r)
 }
 
-func (reg *RegionRouter) UpdateRegionRoutesFromConsul(config *api.ConsulConfiguration) error {
-	// Fetch the list of servers from Consul
-	servers, err := api.ConsulRegionRoutes(config)
-	if err != nil {
-		return err
-	}
+func (reg *RegionRouter) UpdateRegionRoutesFromServerDefinitions(servers []*api.ServerDefinition) error {
+	reg.ResetRegionServers()
 
 	for _, srv := range servers {
 		if srv.DefaultServer {
@@ -180,4 +182,16 @@ func (reg *RegionRouter) UpdateRegionRoutesFromConsul(config *api.ConsulConfigur
 	}
 
 	return nil
+}
+
+func (reg *RegionRouter) UpdateRegionRoutesFromConsul(config *api.ConsulConfiguration) error {
+	reg.ResetRegionServers()
+
+	// Fetch the list of servers from Consul
+	servers, err := api.ConsulRegionRoutes(config)
+	if err != nil {
+		return err
+	}
+
+	return reg.UpdateRegionRoutesFromServerDefinitions(servers)
 }


### PR DESCRIPTION
Consul provides a watch API that we can use for watching the defined tag and service for any changes in the registration state. We can use this mechanism to automatically synchronize our map of region handlers, gracefully handling cases where they come and go.